### PR TITLE
Add GeoLens MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Then ask Claude things like *"is there an MCP server for STAC imagery?"* or *"tr
 
 <!-- AUTOGEN:START -->
 
-**83 servers tracked** across 10 categories.
+**84 servers tracked** across 11 categories.
 
 _Health checked 2026-08-19 (active = repo pushed within 12 months): 🟢 active 55 · 🟡 stale 13 · ⚪ hosted 15._
 
@@ -43,6 +43,7 @@ _Health checked 2026-08-19 (active = repo pushed within 12 months): 🟢 active 
 - [Weather & climate](#weather--climate) (11)
 - [Desktop & enterprise GIS (QGIS, ArcGIS)](#desktop--enterprise-gis-qgis-arcgis) (9)
 - [General GIS / geoprocessing toolkits](#general-gis--geoprocessing-toolkits) (4)
+- [Geospatial data access & catalogs](#geospatial-data-access--catalogs) (1)
 - [Aviation & maritime tracking (ADS-B, AIS)](#aviation--maritime-tracking-ads-b-ais) (5)
 - [Other (IP geolocation, misc)](#other-ip-geolocation-misc) (6)
 
@@ -157,6 +158,12 @@ _Health checked 2026-08-19 (active = repo pushed within 12 months): 🟢 active 
 | [gdal-mcp](https://github.com/JordanGunn/gdal-mcp) | GDAL-style raster/vector workflows (Rasterio, GeoPandas, PyProj) — conversion, reprojection, COG, metadata | Python | JordanGunn / Wayfinder-Foundry | community | 🟢 active |
 | [geoserver-mcp](https://github.com/mahdin75/geoserver-mcp) | Drives the GeoServer REST API — manage workspaces/layers/styles, CQL spatial queries, WMS/WFS access | Python | mahdin75 | community | 🟢 active |
 | [gis-mcp](https://github.com/mahdin75/gis-mcp) | Connects LLMs to core GIS libraries (Shapely, PyProj, GeoPandas, Rasterio, PySAL) for geometry, projections, raster & spatial stats | Python | mahdin75 | community | 🟢 active |
+
+### Geospatial data access & catalogs
+
+| Server | Description | Lang | By | Type | Health |
+| --- | --- | --- | --- | --- | --- |
+| [GeoLens MCP](https://github.com/geolens-io/geolens/tree/main/mcp) | Read-only access to a self-hosted GeoLens instance: catalog search, dataset schemas, GeoJSON features, saved maps & sandboxed read-only SQL | Python | GeoLens | official | — |
 
 ### Aviation & maritime tracking (ADS-B, AIS)
 

--- a/servers.yaml
+++ b/servers.yaml
@@ -792,3 +792,14 @@ servers:
     language: TypeScript
     tags: [timezone, sun, coordinates]
     added: 2026-08-05
+  - name: GeoLens MCP
+    url: https://github.com/geolens-io/geolens/tree/main/mcp
+    description: "Read-only access to a self-hosted GeoLens instance: catalog search, dataset schemas, GeoJSON features, saved maps & sandboxed read-only SQL"
+    category: data_access
+    author: GeoLens
+    language: Python
+    official: true
+    vendor_orgs: [geolens-io]
+    transport: stdio
+    tags: [catalog, postgis, ogc-api, stac]
+    added: 2026-08-21


### PR DESCRIPTION
Adds the GeoLens MCP server under Geospatial data access & catalogs (first entry in that category, already in the categories map). It gives agents read-only access to a self-hosted GeoLens instance: catalog search, schemas, features, maps, and sandboxed SQL. On PyPI as geolens-mcp, Apache-2.0. README regenerated with the generator script.

Disclosure: I'm the author.