### PR TITLE
Add Scigantic MCP (data_access)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Then ask Claude things like *"is there an MCP server for STAC imagery?"* or *"tr
 
 <!-- AUTOGEN:START -->
 
-**86 servers tracked** across 11 categories.
+**87 servers tracked** across 11 categories.
 
 _Health checked 2026-08-26 (active = repo pushed within 12 months): 🟢 active 56 · 🟡 stale 15 · ⚪ hosted 15._
 
@@ -43,7 +43,7 @@ _Health checked 2026-08-26 (active = repo pushed within 12 months): 🟢 active 
 - [Weather & climate](#weather--climate) (11)
 - [Desktop & enterprise GIS (QGIS, ArcGIS)](#desktop--enterprise-gis-qgis-arcgis) (9)
 - [General GIS / geoprocessing toolkits](#general-gis--geoprocessing-toolkits) (5)
-- [Geospatial data access & catalogs](#geospatial-data-access--catalogs) (1)
+- [Geospatial data access & catalogs](#geospatial-data-access--catalogs) (2)
 - [Aviation & maritime tracking (ADS-B, AIS)](#aviation--maritime-tracking-ads-b-ais) (5)
 - [Other (IP geolocation, misc)](#other-ip-geolocation-misc) (6)
 
@@ -166,6 +166,7 @@ _Health checked 2026-08-26 (active = repo pushed within 12 months): 🟢 active 
 | Server | Description | Lang | By | Type | Health |
 | --- | --- | --- | --- | --- | --- |
 | [GeoLens MCP](https://github.com/geolens-io/geolens/tree/main/mcp) | Read-only access to a self-hosted GeoLens instance: catalog search, dataset schemas, GeoJSON features, saved maps & sandboxed read-only SQL | Python | GeoLens | official | 🟢 active |
+| [Scigantic MCP](https://github.com/Scigantic/scigantic-mcp) | Cross-domain scientific dataset catalog and schema cards (genomics, proteomics, imaging, and a large Earth-observation/geospatial footprint), with per-dataset access snippets for agents | Python | Scigantic | official | — |
 
 ### Aviation & maritime tracking (ADS-B, AIS)
 

--- a/servers.yaml
+++ b/servers.yaml
@@ -821,3 +821,15 @@ servers:
     transport: stdio
     tags: [catalog, postgis, ogc-api, stac]
     added: 2026-08-21
+  - name: Scigantic MCP
+    url: https://github.com/Scigantic/scigantic-mcp
+    description: "Cross-domain scientific dataset catalog and schema cards (genomics, proteomics, imaging, and a large Earth-observation/geospatial footprint), with per-dataset access snippets for agents"
+    category: data_access
+    author: Scigantic
+    language: Python
+    official: true
+    vendor_orgs: [Scigantic]
+    transport: stdio
+    tags: [catalog, schema-cards, cross-domain, dataset-discovery, geospatial]
+    note: "also runs as a public, zero-auth hosted endpoint at https://api.scigantic.com/mcp (Streamable HTTP)"
+    added: 2026-08-28


### PR DESCRIPTION
## Summary

Adds [Scigantic](https://scigantic.com) to `data_access`: a cross-domain scientific dataset catalog (genomics, proteomics, imaging, and a large Earth-observation/geospatial footprint) that generates a structured "schema card" per dataset with a per-language access snippet, so an agent can pull data into its own environment without a human downloading anything first.

- **Repo:** https://github.com/Scigantic/scigantic-mcp (public, MIT-0, on PyPI as `scigantic-mcp`)
- **Also reachable as a public, zero-auth hosted endpoint:** `https://api.scigantic.com/mcp` (Streamable HTTP), noted in the entry
- `official: true` backed by `vendor_orgs: [Scigantic]` (I'm the maintainer)

## Checklist

- [x] Entry added to `servers.yaml` under `data_access`
- [x] `python scripts/generate_readme.py` run, `README.md` committed
- [x] `generate_readme.py --check` passes
- [x] Ran the schema/category/duplicate-URL check from `verify.yml` locally — passes
- [x] Ran the changed-entry checks from `verify.yml` locally (URL resolves 200, no redirect; `official` claim verified against `vendor_orgs`) — pass